### PR TITLE
Use dynamic allocation of major device number

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -56,7 +56,7 @@ MODULE_DESCRIPTION( DRIVER_DESC );
 MODULE_LICENSE("GPL");
 
 
-#define TTY0TTY_MAJOR		240	/* experimental range */
+#define TTY0TTY_MAJOR		0	/* dynamic allocation of major number */
 #define TTY0TTY_MINORS		8	/* device number, always even*/
 
 /* fake UART values */


### PR DESCRIPTION
I had a conflict on one system that had already assigned 240 to a hidraw device (my mouse).

Passing zero for the major number allows the system to assign a free number.