### PR TITLE
Fixes module/tty0tty.c:782:3: error: ‘fallthrough’ undeclared

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,12 @@
-tty0tty-dkms (1.41) unstable; urgency=low
+tty0tty (1.41) buster; urgency=low
 
   * Fixes warning: "tty_alloc_driver" redefined
   * Fixes #2 error: ‘fallthrough’ undeclared
-  * Fixes #1 Issue
+  * Fixes #1 Issue: install debhelper dependency
 
- -- epsilonrt <epsilonrt@gmail.com>  Fri, 10 Mar 2023 18:21:22 +0100
+ -- Pascal Jean <pascal.jean@piduino.org>  Fri, 10 Mar 2023 18:21:22 +0100
 
-tty0tty-dkms (1.4) unstable; urgency=low
+tty0tty (1.4) buster; urgency=low
 
   * Add missing functions to 6.1.0 compatibility
   * ssniffer utility added
@@ -28,7 +28,7 @@ tty0tty-dkms (1.4) unstable; urgency=low
 
  -- lcgamboa <lcgamboa@yahoo.com>  Thu, 19 Jan 2023 22:45:20 -0300
 
-tty0tty-dkms (1.3) unstable; urgency=low
+tty0tty (1.3) stretch; urgency=low
 
   * Update README.md
   * Add README.md
@@ -48,25 +48,25 @@ tty0tty-dkms (1.3) unstable; urgency=low
   * Initial commit
   * device file permission info updated
 
- -- epsilonrt <epsilonrt@gmail.com>  Tue, 11 Feb 2020 23:31:37 +0100
+ -- Pascal Jean <pascal.jean@piduino.org>  Tue, 11 Feb 2020 23:31:37 +0100
 
-tty0tty-dkms (1.2) unstable; urgency=low
+tty0tty (1.2) unstable; urgency=low
 
   * kernel 3.10.2 support
 
  -- Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>  Tue, 11 Aug 2015 13:47:30 -0300
 
-tty0tty-dkms (1.1) unstable; urgency=low
+tty0tty (1.1) unstable; urgency=low
 
   * bug fix: mcr set to 0 when port is closed
 
  -- Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>  Tue, 11 Aug 2015 13:43:34 -0300
 
-tty0tty-dkms (1.0) unstable; urgency=low
+tty0tty (1.0) unstable; urgency=low
 
   * bug fix
 
  -- Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>  Tue, 11 Aug 2015 13:37:38 -0300
 
-tty0tty-dkms (0.9) unstable; urgency=low
+tty0tty (0.9) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,72 @@
-tty0tty (1.4-0) stretch; urgency=medium
+tty0tty-dkms (1.41) unstable; urgency=low
 
-  * Initial package.
+  * Fixes warning: "tty_alloc_driver" redefined
+  * Fixes #2 error: ‘fallthrough’ undeclared
+  * Fixes #1 Issue
 
- -- Pascal Jean <pascal.jean@piduino.org>  Tue, 11 Feb 2020 21:14:21 +0100
+ -- epsilonrt <epsilonrt@gmail.com>  Fri, 10 Mar 2023 18:21:22 +0100
+
+tty0tty-dkms (1.4) unstable; urgency=low
+
+  * Add missing functions to 6.1.0 compatibility
+  * ssniffer utility added
+  * Support to show baudrate parameter in sysfs and version update
+  * removing warnings
+  * Readme links updated
+  * Merge pull request #7 from jjguti/fix/support-5.15
+  * Fix building with 5.15
+  * support to kernel 5.14
+  * Merge pull request #5 from rhulme/master
+  * Use dynamic allocation of major device number
+  * Merge pull request #4 from rhulme/master
+  * Link signal lines (CTS,RTS etc.) together properly.
+  * Make indentation consistent and tidy up trailing whitespace
+  * chg: Readme updated !minor
+  * makefile updated
+  * Makefile updated
+  * Merge pull request #2 from epsilonrt/master
+
+ -- lcgamboa <lcgamboa@yahoo.com>  Thu, 19 Jan 2023 22:45:20 -0300
+
+tty0tty-dkms (1.3) unstable; urgency=low
+
+  * Update README.md
+  * Add README.md
+  * Add debian package tree
+  * Readme updated
+  * dkms support added
+  * debug message paramters fixed
+  * break_ctl added
+  * TCGETS2 and TCSETS2 added
+  * new ioctl TCGETS TCSETS TCFLSH implemented
+  * Readme updated
+  * README updated
+  * module Makefile install bug fixed
+  * Makefile install created
+  * Merge branch 'master' of https://github.com/lcgamboa/tty0tty
+  * Delete LICENSE
+  * Initial commit
+  * device file permission info updated
+
+ -- epsilonrt <epsilonrt@gmail.com>  Tue, 11 Feb 2020 23:31:37 +0100
+
+tty0tty-dkms (1.2) unstable; urgency=low
+
+  * kernel 3.10.2 support
+
+ -- Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>  Tue, 11 Aug 2015 13:47:30 -0300
+
+tty0tty-dkms (1.1) unstable; urgency=low
+
+  * bug fix: mcr set to 0 when port is closed
+
+ -- Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>  Tue, 11 Aug 2015 13:43:34 -0300
+
+tty0tty-dkms (1.0) unstable; urgency=low
+
+  * bug fix
+
+ -- Luis Claudio Gamboa Lopes <lcgamboa@yahoo.com>  Tue, 11 Aug 2015 13:37:38 -0300
+
+tty0tty-dkms (0.9) unstable; urgency=low
+

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -75,7 +75,9 @@ static int kernel_termios_to_user_termios_1(struct termios __user *u,
 int tty_check_change(struct tty_struct *tty);
 speed_t tty_termios_input_baud_rate(struct ktermios *termios);
 #else
+#ifndef tty_alloc_driver
 #define tty_alloc_driver(x, y) alloc_tty_driver(x)
+#endif
 #define tty_driver_kref_puf(x) put_tty_driver(x)
 #endif
 

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -779,7 +779,11 @@ static int tty0tty_ioctl_tcflsh(struct tty_struct *tty,
 			tty_unthrottle(tty);
 	 	        tty_driver_flush_buffer(tty);
 		}
-		fallthrough; 
+#if defined(__has_attribute)
+#if __has_attribute(__fallthrough__)
+		__attribute__((__fallthrough__));
+#endif
+#endif
 	case TCOFLUSH:
 		tty_driver_flush_buffer(tty);
 		break;


### PR DESCRIPTION
Unable to build module on Debian Buster 4.19.0-23 (GCC 8.3.0) : 

- tty0tty/module/tty0tty.c:782:3: error: ‘fallthrough’ undeclared (first use in this function)  
- tty0tty/module/tty0tty.c:78: warning: "tty_alloc_driver" redefined

```
epsilonrt@buster-vbox:~/src/tty0tty$ uname -r
4.19.0-23-amd64
epsilonrt@buster-vbox:~/src/tty0tty$ gcc --version
gcc (Debian 8.3.0-6) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

epsilonrt@buster-vbox:~/src/tty0tty$ cd module
epsilonrt@buster-vbox:~/src/tty0tty/module$ make
make -C /lib/modules/4.19.0-23-amd64/build M=/home/epsilonrt/src/tty0tty/module modules
make[1] : on entre dans le répertoire « /usr/src/linux-headers-4.19.0-23-amd64 »
  CC [M]  /home/epsilonrt/src/tty0tty/module/tty0tty.o
/home/epsilonrt/src/tty0tty/module/tty0tty.c:78: warning: "tty_alloc_driver" redefined
 #define tty_alloc_driver(x, y) alloc_tty_driver(x)
 
In file included from /usr/src/linux-headers-4.19.0-23-common/include/linux/tty.h:9,
                 from /home/epsilonrt/src/tty0tty/module/tty0tty.c:36:
/usr/src/linux-headers-4.19.0-23-common/include/linux/tty_driver.h:345: note: this is the location of the previous definition
 #define tty_alloc_driver(lines, flags) \
 
/home/epsilonrt/src/tty0tty/module/tty0tty.c: In function ‘tty0tty_ioctl_tcflsh’:
/home/epsilonrt/src/tty0tty/module/tty0tty.c:782:3: error: ‘fallthrough’ undeclared (first use in this function)
   fallthrough;
   ^~~~~~~~~~~
/home/epsilonrt/src/tty0tty/module/tty0tty.c:782:3: note: each undeclared identifier is reported only once for each function it appears in
make[4]: *** [/usr/src/linux-headers-4.19.0-23-common/scripts/Makefile.build:315: /home/epsilonrt/src/tty0tty/module/tty0tty.o] Error 1
make[3]: *** [/usr/src/linux-headers-4.19.0-23-common/Makefile:1566: _module_/home/epsilonrt/src/tty0tty/module] Error 2
make[2]: *** [Makefile:146: sub-make] Error 2
make[1]: *** [Makefile:8: all] Error 2
make[1] : on quitte le répertoire « /usr/src/linux-headers-4.19.0-23-amd64 »
make: *** [Makefile:30: all] Error 2
```