### PR TITLE
Added parity bit support.

### DIFF
--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -342,8 +342,9 @@ static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer, in
 //        tty->low_latency=1;
 	  if(ttyx != NULL)
 	  {
-		  if((tty->termios.c_cflag & PARENB) && (tty->termios.c_cflag & PARODD))
+		  if((tty->termios.c_cflag & PARENB) && (tty->termios.c_cflag & CMSPAR) && (tty->termios.c_cflag & PARODD))
 		  {
+			  /* MARK parity bit. */
 			  tty_insert_flip_string_fixed_flag(ttyx->port, buffer, TTY_PARITY, count);
 		  }
 		  else

--- a/module/tty0tty.c
+++ b/module/tty0tty.c
@@ -342,7 +342,14 @@ static int tty0tty_write(struct tty_struct *tty, const unsigned char *buffer, in
 //        tty->low_latency=1;
 	  if(ttyx != NULL)
 	  {
-		  tty_insert_flip_string(ttyx->port, buffer, count);
+		  if((tty->termios.c_cflag & PARENB) && (tty->termios.c_cflag & PARODD))
+		  {
+			  tty_insert_flip_string_fixed_flag(ttyx->port, buffer, TTY_PARITY, count);
+		  }
+		  else
+		  {
+		  	  tty_insert_flip_string(ttyx->port, buffer, count);
+		  }
 		  tty_flip_buffer_push(ttyx->port);
 	  }
 	}


### PR DESCRIPTION
When the userspace program sets the serial port settings to include a parity bit, and that parity bit is set to odd, the module should send the bytes with the parity flag.