### PR TITLE
Fix build with glibc >= 2.42 (termio.h removed)

### DIFF
--- a/pts/tty0tty.c
+++ b/pts/tty0tty.c
@@ -32,7 +32,11 @@
 #include <sys/select.h>
 #include <errno.h>
 
+#if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 42))
+#include <termios.h>
+#else
 #include <termio.h>
+#endif
 
 static char buffer[1024];
 


### PR DESCRIPTION
## Summary
- `termio.h` was removed from glibc in version 2.42 (released July 2025)
- Conditionally include `<termios.h>` for glibc >= 2.42, while maintaining backward compatibility with older glibc versions that still have `<termio.h>`